### PR TITLE
Change nginx rules

### DIFF
--- a/docker/nginx.conf.d
+++ b/docker/nginx.conf.d
@@ -45,8 +45,7 @@ http {
         types {                                                                                        
             application/wasm wasm;                                                                     
         }                                                                                              
-        rewrite /landing.html / last;                                                                  
-        rewrite /landing / last;     
+        try_files /index.html =404;
         root /var/www;
     }
 }


### PR DESCRIPTION
Fixed issue: reloading any page (except / and / landing page) failed with 404 error

How to test (on Linux):
1. git clone git@github.com:tonlabs/tonos-se.git
2. cd tonos-se && git checkout bugfix-tonlive-reload
3. Run TON OS SE: `docker run -d --name local-node -e USER_AGREEMENT=yes -p80:80 tonlabs/local-node`
4. Open http://localhost
5. Open any link (e.g. http://localhost/transactions
6. Reload page
If you see the same page, everything is correct, bug  is fixed 